### PR TITLE
Fix timeout, stdio options, and switch dep to tmp.

### DIFF
--- a/lib/create-tmpdir.ts
+++ b/lib/create-tmpdir.ts
@@ -1,35 +1,33 @@
-import { tmpdir } from "os";
-import { join } from "path";
-import * as rimraf from "rimraf";
+import * as tmp from "tmp";
 import { IDisposable } from "./types";
+
+tmp.setGracefulCleanup();
 
 export interface ITmpDir extends IDisposable {
   path: string;
 }
 
-/* tslint:disable:no-var-requires */
-const mktemp: {
-  createDir(
-    template: string,
-    callback: (err: Error | undefined, path: string) => void,
-  ): void;
-} = require("mktemp");
-/* tslint:enable:no-var-requires */
-
-export default async function createTmpDir(customRoot?: string): Promise<ITmpDir> {
-  const root = customRoot || tmpdir();
-  const templatePath = join(root, "tmpXXXXXX");
-  const path = await new Promise<string>((resolve, reject) => {
-    mktemp.createDir(templatePath, (e, p) => (e ? reject(e) : resolve(p)));
-  });
-  function dispose() {
-    return new Promise<void>((resolve, reject) => {
-      rimraf(path, e => (e ? reject(e) : resolve()));
-    }).catch(e => {
-      /* tslint:disable:no-console */
-      console.error(e);
-      /* tslint:enable:no-console */
-    });
+export default async function createTmpDir(
+  customRoot?: string,
+): Promise<ITmpDir> {
+  const options: tmp.Options = {
+    unsafeCleanup: true,
+  };
+  if (customRoot !== undefined) {
+    options.dir = customRoot;
   }
-  return { path, dispose };
+  const tmpDir = tmp.dirSync(options);
+  return {
+    path: tmpDir.name,
+    dispose() {
+      try {
+        tmpDir.removeCallback();
+      } catch (e) {
+        /* tslint:disable:no-console */
+        console.error(e);
+        /* tslint:enable:no-console */
+      }
+      return Promise.resolve();
+    },
+  };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -124,6 +124,7 @@ export interface ISpawnOptions {
   disableDefaultArguments?: boolean;
   additionalArguments?: string[];
   userDataRoot?: string;
+  stdio?: "pipe" | "ignore" | "inherit" | null;
 }
 
 export interface IBrowserProcess extends IDisposable {

--- a/package.json
+++ b/package.json
@@ -43,12 +43,11 @@
   },
   "dependencies": {
     "@types/node": "*",
-    "@types/rimraf": "*",
+    "@types/tmp": "^0.0.33",
     "@types/ws": "*",
     "chrome-launcher": "^0.10.2",
     "execa": "^0.11.0",
-    "mktemp": "^0.4.0",
-    "rimraf": "^2.5.1",
+    "tmp": "^0.0.33",
     "ws": "^6.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,9 +53,10 @@
   "devDependencies": {
     "@types/execa": "^0.9.0",
     "@types/got": "^8.3.3",
+    "@types/node": "^10.9.2",
     "@types/tape": "^4.2.32",
     "faucet": "0.0.1",
-    "got": "^9.0.0",
+    "got": "^9.1.0",
     "prettier": "^1.14.0",
     "tape": "^4.9.1",
     "tslint": "^5.11.0",

--- a/protocol/1-2.ts
+++ b/protocol/1-2.ts
@@ -1,6 +1,6 @@
 /**
  * Debugging Protocol 1.2 Domains
- * Generated on Mon Aug 20 2018 10:05:40 GMT-0700 (PDT)
+ * Generated on Wed Sep 05 2018 11:32:10 GMT-0700 (PDT)
  */
 /* tslint:disable */
 import { IDebuggingProtocolClient } from "../lib/types";

--- a/protocol/1-3.ts
+++ b/protocol/1-3.ts
@@ -1,6 +1,6 @@
 /**
  * Debugging Protocol Domains
- * Generated on Mon Aug 20 2018 10:05:40 GMT-0700 (PDT)
+ * Generated on Wed Sep 05 2018 11:32:10 GMT-0700 (PDT)
  */
 /* tslint:disable */
 import { IDebuggingProtocolClient } from "../lib/types";
@@ -2219,7 +2219,7 @@ export namespace Page {
   /** Unique script identifier. */
   export type ScriptIdentifier = string;
   /** Transition type. */
-  export type TransitionType = "link" | "typed" | "auto_bookmark" | "auto_subframe" | "manual_subframe" | "generated" | "auto_toplevel" | "form_submit" | "reload" | "keyword" | "keyword_generated" | "other";
+  export type TransitionType = "link" | "typed" | "address_bar" | "auto_bookmark" | "auto_subframe" | "manual_subframe" | "generated" | "auto_toplevel" | "form_submit" | "reload" | "keyword" | "keyword_generated" | "other";
   /** Navigation history entry. */
   export interface NavigationEntry {
     /** Unique id of the navigation history entry. */

--- a/protocol/v8.ts
+++ b/protocol/v8.ts
@@ -1,6 +1,6 @@
 /**
  * Debugging Protocol 1.3 Domains
- * Generated on Mon Aug 20 2018 10:05:40 GMT-0700 (PDT)
+ * Generated on Wed Sep 05 2018 11:32:10 GMT-0700 (PDT)
  */
 /* tslint:disable */
 import { IDebuggingProtocolClient } from "../lib/types";

--- a/test/index.ts
+++ b/test/index.ts
@@ -2,10 +2,19 @@ import * as tape from "tape";
 import { createSession } from "../index";
 import { HeapProfiler, Page, Target } from "../protocol/tot";
 
+const additionalArguments = [
+  "--headless",
+  "--disable-gpu",
+  "--hide-scrollbars",
+  "--mute-audio",
+  "--disable-logging",
+];
+
 tape("test REST API", async t => {
   await createSession(async session => {
     const browser = await session.spawnBrowser({
-      additionalArguments: ["--headless"],
+      additionalArguments,
+      stdio: "ignore",
       windowSize: { width: 320, height: 640 },
     });
     const apiClient = session.createAPIClient(
@@ -33,7 +42,8 @@ tape("test REST API", async t => {
 tape("test debugging protocol domains", async t => {
   await createSession(async session => {
     const browser = await session.spawnBrowser({
-      additionalArguments: ["--headless"],
+      additionalArguments,
+      stdio: "ignore",
     });
     const apiClient = session.createAPIClient(
       "localhost",
@@ -64,7 +74,8 @@ tape("test debugging protocol domains", async t => {
 tape("test browser protocol", async t => {
   await createSession(async session => {
     const browser = await session.spawnBrowser({
-      additionalArguments: ["--headless"],
+      additionalArguments,
+      stdio: "ignore",
     });
 
     const browserClient = await session.openDebuggingProtocol(

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,6 +36,10 @@
   version "10.7.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.7.1.tgz#b704d7c259aa40ee052eec678758a68d07132a2e"
 
+"@types/node@^10.9.2":
+  version "10.9.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
+
 "@types/node@^9.3.0":
   version "9.6.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.28.tgz#198927ce0786106ec2a7c8652d46d5f8b87bfc5f"
@@ -341,16 +345,16 @@ glob@^7.0.5, glob@^7.1.1, glob@~7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-got@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-9.0.0.tgz#8673d2838adbac8a2e4a07e5772e238c701e9b7c"
+got@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-9.1.0.tgz#e31aa530bf953ca51599c5722039f891e49cf2ca"
   dependencies:
     "@sindresorhus/is" "^0.11.0"
     cacheable-request "^4.0.1"
     decompress-response "^3.3.0"
     duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    mimic-response "^1.0.0"
+    get-stream "^4.0.0"
+    mimic-response "^1.0.1"
     p-cancelable "^0.5.0"
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
@@ -459,7 +463,7 @@ lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
 
-mimic-response@^1.0.0:
+mimic-response@^1.0.0, mimic-response@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,23 +22,11 @@
   dependencies:
     "@types/node" "*"
 
-"@types/glob@*":
-  version "5.0.35"
-  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.35.tgz#1ae151c802cece940443b5ac246925c85189f32a"
-  dependencies:
-    "@types/events" "*"
-    "@types/minimatch" "*"
-    "@types/node" "*"
-
 "@types/got@^8.3.3":
   version "8.3.3"
   resolved "https://registry.yarnpkg.com/@types/got/-/got-8.3.3.tgz#8a0441ea88550c5d3c34729ae1aaa883f6bd4320"
   dependencies:
     "@types/node" "*"
-
-"@types/minimatch@*":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/mkdirp@^0.3.29":
   version "0.3.29"
@@ -52,13 +40,6 @@
   version "9.6.28"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.28.tgz#198927ce0786106ec2a7c8652d46d5f8b87bfc5f"
 
-"@types/rimraf@*":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.2.tgz#7f0fc3cf0ff0ad2a99bb723ae1764f30acaf8b6e"
-  dependencies:
-    "@types/glob" "*"
-    "@types/node" "*"
-
 "@types/rimraf@^0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"
@@ -68,6 +49,10 @@
   resolved "https://registry.yarnpkg.com/@types/tape/-/tape-4.2.32.tgz#1188330d22c4e822648c344faa070277737982d9"
   dependencies:
     "@types/node" "*"
+
+"@types/tmp@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
 
 "@types/ws@*":
   version "6.0.0"
@@ -502,10 +487,6 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mktemp@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mktemp/-/mktemp-0.4.0.tgz#6d0515611c8a8c84e484aa2000129b98e981ff0b"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -541,6 +522,10 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
 p-cancelable@^0.5.0:
   version "0.5.0"
@@ -610,7 +595,7 @@ resumer@~0.0.0:
   dependencies:
     through "~2.3.4"
 
-rimraf@^2.5.1, rimraf@^2.6.1:
+rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
@@ -724,6 +709,12 @@ through2@~0.2.3:
 through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-readable-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fix timeout for DevToolsActivePort file to match behavior of chromedriver https://chromium.googlesource.com/chromium/src/+/6fd4390daea50497e5ead4583829e2e8f9b215b2/chrome/test/chromedriver/chrome_launcher.cc#445

Add stdio option to spawnBrowser so you can "ignore" stdio (defaults to current behavior of inheriting the process stdio).

Fix issues with last update to execa (changed buffer option and it creates a promise for the spawned process).